### PR TITLE
Ability to use Vuex-decorators for Vuex Modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10810,6 +10810,12 @@
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.0.tgz",
       "integrity": "sha512-mdHeHT/7u4BncpUZMlxNaIdcN/HIt1GsGG5LKByArvYG/v6DvHcOxvDCts+7SRdCoIRGllK8IMZvQtQXLppDYg=="
     },
+    "vuex-module-decorators": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/vuex-module-decorators/-/vuex-module-decorators-0.9.8.tgz",
+      "integrity": "sha512-yyh9+0mO7NYZxw5BlXWNA/lHioVOUL0muDpJPL9ssAvje2PHQfFSOCSridK4vA3HasjyaGRtTPJKH7+7UCcpwg==",
+      "dev": true
+    },
     "watchpack": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0",
     "typescript": "~3.2.2",
-    "vue-template-compiler": "^2.5.21"
+    "vue-template-compiler": "^2.5.21",
+    "vuex-module-decorators": "^0.9.8"
   }
 }

--- a/src/lib/entities/Application.ts
+++ b/src/lib/entities/Application.ts
@@ -1,0 +1,7 @@
+import { IApplication } from "@/lib/interfaces/ISession";
+
+export default class Application implements IApplication {
+  version: string = "";
+  releaseDate: Date = new Date();
+  features: any;
+}

--- a/src/lib/entities/SessionState.ts
+++ b/src/lib/entities/SessionState.ts
@@ -1,0 +1,10 @@
+import { IApplication, IUser, ITenant, ILoginInformation } from "@/lib/interfaces/ISession";
+import Application from "@/lib/entities/Application";
+import User from "@/lib/entities/User";
+import Tenant from "@/lib/entities/Tenant";
+
+export default class SessionState implements ILoginInformation {
+  application: IApplication = new Application();
+  user: IUser = new User();
+  tenant: ITenant = new Tenant();
+}

--- a/src/lib/entities/Tenant.ts
+++ b/src/lib/entities/Tenant.ts
@@ -1,0 +1,7 @@
+import { ITenant } from "@/lib/interfaces/ISession";
+
+export default class Tenant implements ITenant {
+  tenancyName: string = "";
+  name: string = "";
+  id: number = 0;
+}

--- a/src/lib/entities/User.ts
+++ b/src/lib/entities/User.ts
@@ -1,0 +1,9 @@
+import { IUser } from "@/lib/interfaces/ISession";
+
+export default class User implements IUser {
+  name: string = "";
+  surname: string = "";
+  userName: string = "";
+  emailAddress: string = "";
+  id: number = 0;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,10 +3,9 @@ import App from "./App.vue";
 import router from "./router";
 import store from "./store/store";
 import UserConfigService from "@/services/services/UserConfigurationService";
-import SessionService from "@/services/services/SessionService";
 import Util from "@/lib/util";
 import appConsts from "@/lib/appconsts";
-import { ILoginInformation } from "./lib/interfaces/ISession";
+import { SessionModule } from "@/store/modules/session";
 
 Vue.config.productionTip = false;
 
@@ -14,7 +13,6 @@ Util.setLocalizationCookieIfNotSet(appConsts.AppConsts.localizationCookieName);
 
 // setting the global abp object here
 const userConfigService: UserConfigService = new UserConfigService();
-const sessionService: SessionService = new SessionService();
 
 userConfigService.getUserConfiguration().then(data => {
   Util.abp = Util.extend(true, Util.abp, data.result);
@@ -23,8 +21,7 @@ userConfigService.getUserConfiguration().then(data => {
     store,
     // tslint:disable-next-line:typedef
     async mounted() {
-      const loginInfo: ILoginInformation = await sessionService.getLoginInformation();
-      console.log(loginInfo);
+      await SessionModule.InitSession();
     },
     render: h => h(App)
   }).$mount("#app");

--- a/src/services/services/SessionService.ts
+++ b/src/services/services/SessionService.ts
@@ -16,4 +16,5 @@ class SessionService implements ISessionService {
   }
 }
 
-export default SessionService;
+const sessionService: SessionService = new SessionService();
+export default sessionService;

--- a/src/store/modules/session.ts
+++ b/src/store/modules/session.ts
@@ -1,2 +1,27 @@
+import store from "@/store/store";
 import util from "@/lib/util";
-import SessionService from "@/services/services/SessionService";
+import sessionService from "@/services/services/SessionService";
+import SessionState from "@/lib/entities/SessionState";
+import { Module, VuexModule, Mutation, Action, getModule } from "vuex-module-decorators";
+import { ILoginInformation } from "@/lib/interfaces/ISession";
+
+@Module({ dynamic: true, store, name: "session" })
+export default class Session extends VuexModule {
+  public session = new SessionState();
+
+  @Action({ commit: "INIT_SESSION" })
+  // tslint:disable-next-line:typedef
+  public async InitSession() {
+    const currentSession: ILoginInformation = await sessionService.getLoginInformation();
+    return currentSession;
+  }
+
+  @Mutation
+  // tslint:disable-next-line:typedef
+  private INIT_SESSION(session: ILoginInformation) {
+    console.log("Inside INIT_SESSION: ", session);
+    this.session = session;
+  }
+}
+
+export const SessionModule: Session = getModule(Session);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -3,6 +3,7 @@ import Vuex from "vuex";
 
 Vue.use(Vuex);
 
+// modules will be dynamic
 export default new Vuex.Store({
   state: {},
   mutations: {},


### PR DESCRIPTION
This pull request adds the ability to use Vuex-Decorators for Vuex Modules to easily create strongly typed Veux Modules that work great in Typescript.

This is using the `vuex-module-decorators` package on NPM. To see examples of using this package checkout its GitHub here: https://github.com/championswimmer/vuex-module-decorators